### PR TITLE
Improve color lookup

### DIFF
--- a/src/modules/color.dw
+++ b/src/modules/color.dw
@@ -276,20 +276,17 @@ function getColorEscapeCode() {
   local _defaultColorSymbol="${2}";
   if isEmpty "${_defaultColorSymbol}"; then
     getNoColor;
-   _defaultColorSymbol="${RESULT}";
+    _defaultColorSymbol="${RESULT}";
   fi
-  local _result;
+
+  local _result="";
   local -i _rescode;
 
   if allowsColors; then
-    if    isNotEmpty "${_colorSymbol}" \
-       && evalConstant "${_colorSymbol}"; then
-       _result="${RESULT}";
-    elif   isNotEmpty "${_defaultColorSymbol}" \
-        && evalConstant "${_defaultColorSymbol}"; then
-      _result="${RESULT}";
-#    else
-#      exitWithErrorCode INTERNAL_ERROR "Error getting color ${_colorSymbol} (variable: ${_colorVariableName}) (default: ${_defaultColorVariableName})";
+    if isNotEmpty "${_colorSymbol}" && isNotEmpty "${!_colorSymbol:-}"; then
+      _result="${!_colorSymbol}";
+    elif isNotEmpty "${_defaultColorSymbol}" && isNotEmpty "${!_defaultColorSymbol:-}"; then
+      _result="${!_defaultColorSymbol}";
     fi
   fi
 

--- a/src/modules/echo.dw
+++ b/src/modules/echo.dw
@@ -116,8 +116,7 @@ function echoInColor() {
     getColorEscapeCode "${_color}";
     _colorAux="${RESULT}";
     getNoColor;
-    getColorEscapeCode "${RESULT}";
-    _noColor="${RESULT}";
+    _noColor="${!RESULT:-}";
   fi
 
   if isTrue ${_flagMinusN}; then


### PR DESCRIPTION
## Summary
- optimize getColorEscapeCode to avoid `evalConstant`
- derive reset color directly in echoInColor

## Testing
- `bash test/test-all.sh` *(fails: `/usr/bin/env: ‘dry-wit’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684dd7213bec8321b029154e35bea959