### PR TITLE
Optimize color escape lookups

### DIFF
--- a/src/modules/color.dw
+++ b/src/modules/color.dw
@@ -261,6 +261,29 @@ function COLOR.setCachedAllowsColors() {
   DW.setGlobalInt "${RESULT}" CACHED_ALLOWS_COLORS ${_flag};
 }
 
+# fun: COLOR.getColorValue symbol
+# api: private
+# txt: Retrieves the ANSI escape sequence for a color symbol.
+# opt: symbol: The color symbol.
+# txt: Returns 0/TRUE if the symbol is defined; 1/FALSE otherwise.
+# txt: The variable RESULT contains the escape sequence.
+# use: if COLOR.getColorValue RED; then
+# use:   echo "red: ${RESULT}";
+# use: fi
+function COLOR.getColorValue() {
+  local _symbol="${1}";
+  checkNotEmpty symbol "${_symbol}" 1;
+
+  local _value="${!_symbol}";
+
+  if isEmpty "${_value}"; then
+    return ${FALSE};
+  fi
+
+  export RESULT="${_value}";
+  return ${TRUE};
+}
+
 # fun: getColorEscapeCode name defaultColor?
 # api: public
 # txt: Retrieves the color for given name.
@@ -283,10 +306,10 @@ function getColorEscapeCode() {
 
   if allowsColors; then
     if    isNotEmpty "${_colorSymbol}" \
-       && evalConstant "${_colorSymbol}"; then
+       && COLOR.getColorValue "${_colorSymbol}"; then
        _result="${RESULT}";
     elif   isNotEmpty "${_defaultColorSymbol}" \
-        && evalConstant "${_defaultColorSymbol}"; then
+        && COLOR.getColorValue "${_defaultColorSymbol}"; then
       _result="${RESULT}";
 #    else
 #      exitWithErrorCode INTERNAL_ERROR "Error getting color ${_colorSymbol} (variable: ${_colorVariableName}) (default: ${_defaultColorVariableName})";

--- a/src/modules/echo.dw
+++ b/src/modules/echo.dw
@@ -113,10 +113,10 @@ function echoInColor() {
   local _noColor;
   if allowsColors; then
     _inColor=${TRUE};
-    getColorEscapeCode "${_color}";
+    COLOR.getColorValue "${_color}";
     _colorAux="${RESULT}";
     getNoColor;
-    getColorEscapeCode "${RESULT}";
+    COLOR.getColorValue "${RESULT}";
     _noColor="${RESULT}";
   fi
 


### PR DESCRIPTION
## Summary
- add `COLOR.getColorValue` to retrieve escape sequences without `eval`
- use the new function in `getColorEscapeCode`
- update `echoInColor` to call `COLOR.getColorValue`

## Testing
- `bash test/test-all.sh` *(fails: `/usr/bin/env: ‘dry-wit’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684dd7213bec8321b029154e35bea959