### PR TITLE
Fix logging internal check

### DIFF
--- a/src/modules/logging.dw
+++ b/src/modules/logging.dw
@@ -2283,6 +2283,15 @@ function LOGGING.isInternal() {
     _rescode=${TRUE}
   fi
 
+  if isFalse ${_rescode}; then
+    LOGGING.getInvalidLogCategoriesVariableName
+    local -n _invalidLogCategories="${RESULT}"
+
+    if arrayContains "${_category}" "${_invalidLogCategories[@]}"; then
+      _rescode=${TRUE}
+    fi
+  fi
+
   return ${_rescode}
 
 }


### PR DESCRIPTION
## Summary
- hide invalid log categories in `LOGGING.isInternal`

## Testing
- `bash test/test-all.sh` *(fails: Required module nix-flake.dw not found and tests aborted)*

------
https://chatgpt.com/codex/tasks/task_e_684de75748908321842c8d3b15e3a86e